### PR TITLE
Fix db dump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-autocomplete-light==3.5.1
 django-bootstrap-pagination==1.7.1
 django-bootstrap3==12.1.0
 django-cron==0.5.1
-django-dbbackup==3.3.0
+django-dbbackup==4.0.2
 django-filter==2.4.0
 django-haystack==2.8.1
 djangorestframework==3.11.2

--- a/website/cron.py
+++ b/website/cron.py
@@ -366,7 +366,7 @@ class BackupDaily(LockJob):
             with gzip.open(filepath_compressed, 'wb') as f_out:
                 shutil.copyfileobj(f_in, f_out)
         os.remove(filepath)
-        BackupDaily.remove_old_json_dumps(days_old=30)
+        BackupDaily.remove_old_json_dumps(days_old=settings.JSON_DUMP_KEEP_DAYS)
 
     @staticmethod
     def remove_old_json_dumps(days_old):

--- a/website/cron.py
+++ b/website/cron.py
@@ -356,6 +356,8 @@ class BackupDaily(LockJob):
                 'parliament',
                 'government',
                 'document',
+                'gift',
+                'travel',
                 'stats',
                 'website',
                 stdout=fileout

--- a/website/local_settings_example.py
+++ b/website/local_settings_example.py
@@ -35,6 +35,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'website/static/media/')
 # MEDIA_URL = '/static/media/'
 
 # DBBACKUP
+JSON_DUMP_KEEP_DAYS = 3
 DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
 DBBACKUP_STORAGE_OPTIONS = {'location': os.path.join(BASE_DIR, STATIC_ROOT, 'backup/')}
 

--- a/website/settings.py
+++ b/website/settings.py
@@ -116,6 +116,9 @@ DATABASES = {
     }
 }
 
+# DB dumps
+JSON_DUMP_KEEP_DAYS = 3
+
 
 ##################
 # LOCAL SETTINGS #


### PR DESCRIPTION
Fixes #89 by upgrading the django-dbbackup package.

Also create a setting for the number of days to keep json dumps.